### PR TITLE
Fix incorrect key name in Client#interval_block

### DIFF
--- a/lib/green-button-data/client.rb
+++ b/lib/green-button-data/client.rb
@@ -49,7 +49,7 @@ module GreenButtonData
       end
 
       id ||= options[:interval_block_id]
-      meter_reading_id = options[:meter_Reading_id]
+      meter_reading_id = options[:meter_reading_id]
       usage_point_id = options[:usage_point_id]
       subscription_id = options[:subscription_id]
 

--- a/lib/green-button-data/local_time_parameters.rb
+++ b/lib/green-button-data/local_time_parameters.rb
@@ -16,11 +16,11 @@ module GreenButtonData
       @dst_offset + @tz_offset
     end
 
-    def to_h
+    def to_h(year = Time.now.year)
       {
         dst: {
-          starts_at: dst_starts_at,
-          ends_at: dst_ends_at,
+          starts_at: dst_starts_at(year),
+          ends_at: dst_ends_at(year),
           offset: dst_offset
         },
         tz_offset: tz_offset,

--- a/lib/green-button-data/utilities.rb
+++ b/lib/green-button-data/utilities.rb
@@ -59,7 +59,7 @@ module GreenButtonData
       # need to be added before hitting the first Sunday of month
       day_offset = first_weekday == 0 ? 0 : 7 - first_weekday
 
-      # Return first Monday of the month
+      # Return first Sunday of the month
       first_day + day_offset
     end
 
@@ -78,10 +78,11 @@ module GreenButtonData
     # To retrieve third Friday of July 2015,
     #     nth_weekday_of 2015, 7, 5, 3
     def nth_weekday_of(year = Time.now.year, month = Time.now.month,
-                             weekday = 0, week = 1)
+                       weekday = 0, week = 1)
+      first_day = DateTime.new year, month, 1
 
       # Day offset needed for Nth day of the week
-      first_sunday_of(year, month) + weekday + (week - 1) * 7
+      first_day + weekday_offset(first_day.wday, weekday) + (week - 1) * 7
     end
 
     ##
@@ -110,7 +111,15 @@ module GreenButtonData
         7 + last_weekday - weekday
       end
 
-      last_day - day_offset
+      last_day - weekday_offset(weekday, last_weekday)
+    end
+
+    def weekday_offset(first_weekday, second_weekday)
+      if second_weekday >= first_weekday
+        second_weekday - first_weekday
+      else
+        7 + second_weekday - first_weekday
+      end
     end
 
     ##

--- a/spec/lib/green-button-data/local_time_parameters_spec.rb
+++ b/spec/lib/green-button-data/local_time_parameters_spec.rb
@@ -61,8 +61,8 @@ describe GreenButtonData::LocalTimeParameters do
       it "should populate attributes" do
         instance = collection.first
         expect(instance.id).to eq "1"
-        expect(instance.dst_starts_at).to eq dst_starts_at
-        expect(instance.dst_ends_at).to eq dst_ends_at
+        expect(instance.dst_starts_at 2015).to eq dst_starts_at
+        expect(instance.dst_ends_at 2015).to eq dst_ends_at
         expect(instance.dst_offset).to eq dst_offset
         expect(instance.tz_offset).to eq tz_offset
       end
@@ -78,8 +78,8 @@ describe GreenButtonData::LocalTimeParameters do
 
       it "should populate attributes" do
         expect(local_time_parameters.id).to eq "1"
-        expect(local_time_parameters.dst_starts_at).to eq dst_starts_at
-        expect(local_time_parameters.dst_ends_at).to eq dst_ends_at
+        expect(local_time_parameters.dst_starts_at 2015).to eq dst_starts_at
+        expect(local_time_parameters.dst_ends_at 2015).to eq dst_ends_at
         expect(local_time_parameters.dst_offset).to eq dst_offset
         expect(local_time_parameters.tz_offset).to eq tz_offset
       end
@@ -92,7 +92,7 @@ describe GreenButtonData::LocalTimeParameters do
     end
 
     it "should populate attributes to Hash key values" do
-      expect(local_time_parameters.to_h).to eq({
+      expect(local_time_parameters.to_h 2015).to eq({
         dst: {
           starts_at: dst_starts_at,
           ends_at: dst_ends_at,

--- a/spec/lib/green-button-data/utilities_spec.rb
+++ b/spec/lib/green-button-data/utilities_spec.rb
@@ -46,7 +46,9 @@ describe GreenButtonData::Utilities do
 
   describe "#nth_weekday_of" do
     it "should return the Nth weekday of a given month" do
+      first_friday = @klass.new.nth_weekday_of 2015, 10, 5, 1
       third_wednesday = @klass.new.nth_weekday_of 2015, 10, 3, 3
+      expect(first_friday.day).to eq 2
       expect(third_wednesday.day).to eq 21
     end
   end


### PR DESCRIPTION
Fix a typo in interval_block method from meter_Reading_id to meter_reading_id.

FIXES #2 