### PR TITLE
Fix security vulnerability with libxml2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    green-button-data (0.6.0)
-      faraday (~> 0.9)
-      nokogiri (~> 1.6)
+    green-button-data (0.7.0)
+      faraday (~> 0.11)
+      nokogiri (~> 1.7)
       sax-machine (~> 1.3)
 
 GEM
@@ -19,7 +19,7 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    faraday (0.9.2)
+    faraday (0.12.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
     formatador (0.2.5)
@@ -46,13 +46,11 @@ GEM
     mini_portile2 (2.1.0)
     multipart-post (2.0.0)
     nenv (0.2.0)
-    nokogiri (1.6.8)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     notiffany (0.0.7)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    pkg-config (1.1.7)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -98,3 +96,6 @@ DEPENDENCIES
   guard-rspec
   rspec (~> 3.0)
   webmock (~> 1.21)
+
+BUNDLED WITH
+   1.14.6

--- a/green-button-data.gemspec
+++ b/green-button-data.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'nokogiri', '~> 1.7'
   s.add_dependency 'sax-machine', '~> 1.3'
-  s.add_dependency 'faraday', '~> 0.9'
+  s.add_dependency 'faraday', '~> 0.11'
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'webmock', '~> 1.21'

--- a/green-button-data.gemspec
+++ b/green-button-data.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.platform              = Gem::Platform::RUBY
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency 'nokogiri', '~> 1.6'
+  s.add_dependency 'nokogiri', '~> 1.7'
   s.add_dependency 'sax-machine', '~> 1.3'
   s.add_dependency 'faraday', '~> 0.9'
 

--- a/green-button-data.gemspec
+++ b/green-button-data.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.platform              = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.add_dependency 'nokogiri', '~> 1.7'
   s.add_dependency 'sax-machine', '~> 1.3'

--- a/lib/green-button-data/version.rb
+++ b/lib/green-button-data/version.rb
@@ -1,3 +1,3 @@
 module GreenButtonData
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end


### PR DESCRIPTION
Fixes security vulnerability with libxml2 security advisory by updating dependency versions.

* nokogiri (1.6 → 1.7)
* faraday (0.9 → 0.11)

For more info, see: https://github.com/sparklemotion/nokogiri/issues/1615

After this PR, this gem will require Ruby version 2.1 or higher.