### PR TITLE
Fix duplicated and overwritten key in phase_code.rb

### DIFF
--- a/lib/green-button-data/enumerations/phase_code.rb
+++ b/lib/green-button-data/enumerations/phase_code.rb
@@ -13,7 +13,6 @@ module GreenButtonData
       66 => :b_c,
       72 => :b_av,
       97 => :b_c_n,  # TODO: Check with GB XML schema maintainers? https://github.com/energyos/OpenESPI-Common-java/blob/master/etc/espiDerived.xsd
-      97 => :a_c_n,
       128 => :a,
       129 => :a_n,
       132 => :a_b,


### PR DESCRIPTION
# Issue
I had an issue when using the gem on a rails project : 
`gems/green-button-data-0.7.2/lib/green-button-data/enumerations/phase_code.rb:15: warning: key 97 is duplicated and overwritten on line 16`

# Work 
Removed the wrong line in the file. I spotted it by reading the code [here](https://github.com/energyos/OpenESPI-Common-java/blob/master/etc/espiDerived.xsd#L3000).