### PR TITLE
fix typo in main address parser

### DIFF
--- a/lib/green-button-data/parser/main_address.rb
+++ b/lib/green-button-data/parser/main_address.rb
@@ -28,7 +28,7 @@ module GreenButtonData
       end
 
       element :townDetail, class: TownDetail, as: :town_detail
-      element :streetDetail, class: StreetDetail, as: :town_detail
+      element :streetDetail, class: StreetDetail, as: :street_detail
 
 
       # ESPI Namespacing


### PR DESCRIPTION
PG&E removed the `ns0` namespace from the content elements in the XML response for retail customer requests. This typo in `GreenButtonData::Parser::MainAddress` prevented `streetDetail` information from being saved. 