### PR TITLE
support more PG&E usage summary billing details

### DIFF
--- a/lib/green-button-data/parser/cost_additional_detail_last_period.rb
+++ b/lib/green-button-data/parser/cost_additional_detail_last_period.rb
@@ -1,20 +1,29 @@
 module GreenButtonData
   module Parser
     class CostAdditionalDetailLastPeriod < SummaryMeasurement
-      element :note
-      element :itemKind, class: Integer, as: :item_kind
       element :amount, class: Integer, as: :amount
+      element :itemKind, class: Integer, as: :item_kind
+      element :itemPeriod, class: Interval, as: :item_period
+      element :note
+      element :unitCost, class: Integer, as: :unit_cost
 
       # ESPI Namespacing
-      element :'espi:note', as: :note
+      element :'espi:amount', class: Integer, as: :amount
       element :'espi:itemKind', class: Integer, as: :item_kind
+      element :'espi:itemPeriod', class: Interval, as: :item_period
+      element :'espi:note', as: :note
+      element :'espi:unitCost', class: Integer, as: :unit_cost
 
       # Special case for PG&E generic namespacing
-      element :'ns0:note', as: :note
-      element :'ns0:itemKind', class: Integer, as: :item_kind
-
-      # Special case for SCE generic namespacing
       element :'ns0:amount', class: Integer, as: :amount
+      element :'ns0:itemKind', class: Integer, as: :item_kind
+      element :'ns0:itemPeriod', class: Interval, as: :item_period
+      element :'ns0:note', as: :note
+      element :'ns0:unitCost', class: Integer, as: :unit_cost
+
+      def cost
+        @amount / 100_000.0 if @amount.class == Fixnum
+      end
     end
   end
 end

--- a/spec/fixtures/PGEUsageSummaries.xml
+++ b/spec/fixtures/PGEUsageSummaries.xml
@@ -18,22 +18,78 @@
             </ns0:billingPeriod>
             <ns0:billLastPeriod>23364000</ns0:billLastPeriod>
             <ns0:costAdditionalDetailLastPeriod>
-               <ns0:note>Total Winter Partial Peak Usage</ns0:note>
+               <ns0:amount>1200000</ns0:amount>
+               <ns0:note>Part Peak Energy Charge</ns0:note>
                <ns0:measurement>
                   <ns0:powerOfTenMultiplier>-3</ns0:powerOfTenMultiplier>
                   <ns0:uom>72</ns0:uom>
-                  <ns0:value>106120600</ns0:value>
+                  <ns0:value>100000000</ns0:value>
                </ns0:measurement>
                <ns0:itemKind>3</ns0:itemKind>
+               <ns0:unitCost>12000</ns0:unitCost>
+               <ns0:itemPeriod>
+                  <ns0:duration>2505600</ns0:duration>
+                  <ns0:start>1434006000</ns0:start>
+               </ns0:itemPeriod>
             </ns0:costAdditionalDetailLastPeriod>
             <ns0:costAdditionalDetailLastPeriod>
-               <ns0:note>Total Winter Off Peak Usage</ns0:note>
+               <ns0:amount>3600000</ns0:amount>
+               <ns0:note>Off Peak Energy Charge</ns0:note>
                <ns0:measurement>
                   <ns0:powerOfTenMultiplier>-3</ns0:powerOfTenMultiplier>
                   <ns0:uom>72</ns0:uom>
-                  <ns0:value>398794000</ns0:value>
+                  <ns0:value>400000000</ns0:value>
                </ns0:measurement>
                <ns0:itemKind>3</ns0:itemKind>
+               <ns0:unitCost>9000</ns0:unitCost>
+               <ns0:itemPeriod>
+                  <ns0:duration>2505600</ns0:duration>
+                  <ns0:start>1434006000</ns0:start>
+               </ns0:itemPeriod>
+            </ns0:costAdditionalDetailLastPeriod>
+            <ns0:costAdditionalDetailLastPeriod>
+               <ns0:amount>77000</ns0:amount>
+               <ns0:note>Max Demand Charge</ns0:note>
+               <ns0:measurement>
+                  <ns0:powerOfTenMultiplier>-3</ns0:powerOfTenMultiplier>
+                  <ns0:uom>38</ns0:uom>
+                  <ns0:value>960000</ns0:value>
+               </ns0:measurement>
+               <ns0:itemKind>3</ns0:itemKind>
+               <ns0:unitCost>603000</ns0:unitCost>
+               <ns0:itemPeriod>
+                  <ns0:duration>2505600</ns0:duration>
+                  <ns0:start>1434006000</ns0:start>
+               </ns0:itemPeriod>
+            </ns0:costAdditionalDetailLastPeriod>
+            <ns0:costAdditionalDetailLastPeriod>
+               <ns0:amount>480000</ns0:amount>
+               <ns0:note>Customer Charge</ns0:note>
+               <ns0:measurement>
+                  <ns0:powerOfTenMultiplier>-3</ns0:powerOfTenMultiplier>
+                  <ns0:uom>72</ns0:uom>
+                  <ns0:value>4000000</ns0:value>
+               </ns0:measurement>
+               <ns0:itemKind>4</ns0:itemKind>
+               <ns0:unitCost>120000</ns0:unitCost>
+               <ns0:itemPeriod>
+                  <ns0:duration>2505600</ns0:duration>
+                  <ns0:start>1434006000</ns0:start>
+               </ns0:itemPeriod>
+            </ns0:costAdditionalDetailLastPeriod>
+            <ns0:costAdditionalDetailLastPeriod>
+               <ns0:amount>1000</ns0:amount>
+               <ns0:note>Energy Commission Tax</ns0:note>
+               <ns0:measurement>
+                  <ns0:powerOfTenMultiplier>-3</ns0:powerOfTenMultiplier>
+                  <ns0:uom>72</ns0:uom>
+                  <ns0:value>0</ns0:value>
+               </ns0:measurement>
+               <ns0:itemKind>5</ns0:itemKind>
+               <ns0:itemPeriod>
+                  <ns0:duration>2505600</ns0:duration>
+                  <ns0:start>1434006000</ns0:start>
+               </ns0:itemPeriod>
             </ns0:costAdditionalDetailLastPeriod>
             <ns0:overallConsumptionLastPeriod>
                <ns0:powerOfTenMultiplier>-3</ns0:powerOfTenMultiplier>

--- a/spec/lib/green-button-data/parser/cost_additional_detail_last_period_spec.rb
+++ b/spec/lib/green-button-data/parser/cost_additional_detail_last_period_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+
+describe GreenButtonData::Parser::CostAdditionalDetailLastPeriod do
+  context "PG&E namespace" do
+    let(:feed) { GreenButtonData::Feed }
+
+    let(:cost_additional_details) do
+      feed.parse(pge_usage_summaries).entries.first.content.usage_summary.cost_additional_detail_last_periods
+    end
+
+    subject { cost_additional_details }
+
+    it 'generates an array of detail objects' do
+      expect(subject).to be_an_instance_of(Array)
+
+      subject.each do |obj|
+        expect(obj).to be_a(GreenButtonData::Parser::CostAdditionalDetailLastPeriod)
+      end
+    end
+
+    it 'parses costs' do
+      expect(subject.map(&:cost)).to eq([
+        12.0,
+        36.0,
+        0.77,
+        4.8,
+        0.01
+      ])
+    end
+
+    it 'parses notes' do
+      expect(subject.map(&:note)).to eq([
+        'Part Peak Energy Charge',
+        'Off Peak Energy Charge',
+        'Max Demand Charge',
+        'Customer Charge',
+        'Energy Commission Tax'
+      ])
+    end
+
+    it 'parses measurement values' do
+      expect(subject.map(&:power_of_ten_multiplier)).to eq([
+        :m,
+        :m,
+        :m,
+        :m,
+        :m
+      ])
+
+      expect(subject.map(&:uom)).to eq([
+        :Wh,
+        :Wh,
+        :W,
+        :Wh,
+        :Wh
+      ])
+
+      expect(subject.map(&:value)).to eq([
+        100_000.0,
+        400_000.0,
+        960.0,
+        4_000.0,
+        0
+      ])
+    end
+
+    it 'parses classification code' do
+      expect(subject.map(&:item_kind)).to eq([
+        3,
+        3,
+        3,
+        4,
+        5
+      ])
+    end
+
+    it 'parses the per unit cost, i.e. rate' do
+      expect(subject.map(&:unit_cost)).to eq([
+        12000,
+        9000,
+        603000,
+        120000,
+        nil
+      ])
+    end
+
+    it 'parses the item period values' do
+      expect(subject.map(&:item_period).map(&:duration)).to eq([
+        2505600,
+        2505600,
+        2505600,
+        2505600,
+        2505600
+      ])
+
+      expect(subject.map(&:item_period).map(&:start)).to eq([
+        1434006000,
+        1434006000,
+        1434006000,
+        1434006000,
+        1434006000
+      ])
+    end
+  end
+end

--- a/spec/lib/green-button-data/parser/usage_summary_spec.rb
+++ b/spec/lib/green-button-data/parser/usage_summary_spec.rb
@@ -66,11 +66,7 @@ describe GreenButtonData::Parser::UsageSummary do
     end
 
     it "should parse cost additional detail last period" do
-      expect(subject.cost_additional_detail_last_periods.first).
-      to be_an_instance_of GreenButtonData::Parser::CostAdditionalDetailLastPeriod
-      expect(subject.cost_additional_detail_last_periods.first.value).to eq 106120.6
-      expect(subject.cost_additional_detail_last_periods.first.uom).to eq :Wh
-      expect(subject.cost_additional_detail_last_periods.first.note).to eq 'Total Winter Partial Peak Usage'
+      expect(subject.cost_additional_detail_last_periods.first).to be_a GreenButtonData::Parser::CostAdditionalDetailLastPeriod
     end
 
     it "should parse quality of reading" do


### PR DESCRIPTION

## Changes

- Capture more PG&E UsageSummary `costAdditionalDetailLastPeriod` attributes:
    - itemPeriod
    - unitCost
- PG&E UsageSummary fixture has been updated to the current XML response.
- No breaking changes.

## Pull request requirements checklist

Please ensure all of the requirements below are met. PRs that do not meet these
requirements will not be approved.

- [x] Is there a description of the changes in this pull request?
- [x] Are tests written for the changes?
- [x] Are breaking changes documented?

