### PR TITLE
Gem updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    green-button-data (1.0.0)
+    green-button-data (1.0.3)
       faraday (~> 0.11)
       nokogiri (~> 1.8)
       sax-machine (~> 1.3)
@@ -11,15 +11,13 @@ GEM
   specs:
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    codecov (0.1.14)
-      json
-      simplecov
-      url
+    codecov (0.2.13)
+      simplecov (~> 0.18.0)
     coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    docile (1.3.1)
+    docile (1.3.2)
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
@@ -39,7 +37,6 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.8)
-    json (2.3.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -78,13 +75,11 @@ GEM
     safe_yaml (1.0.4)
     sax-machine (1.3.2)
     shellany (0.0.1)
-    simplecov (0.16.1)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.3)
     thor (0.20.3)
-    url (0.3.2)
     webmock (1.24.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)


### PR DESCRIPTION
## Changes

- Ran `bundle install` to update the version in Gemfile.lock to reflect the most recent release version.
- Update `codecov` gem version. All previous versions of this gem have been yanked from the RubyGems repository: 
  https://rubygems.org/gems/codecov/versions
- Deprecation warning for Codecov was issued in July 2020:
  https://github.com/codecov/codecov-ruby/blob/master/README.md#deprecation-warning
## Pull request requirements checklist

Please ensure all of the requirements below are met. PRs that do not meet these
requirements will not be approved.

- [x] Is there a description of the changes in this pull request?
- [x] Are tests written for the changes?
- [x] Are breaking changes documented?

